### PR TITLE
🐛 Fix event channel: convert speed from m/s to km/h

### DIFF
--- a/android/src/main/kotlin/de/buseslaar/tracking/activity_tracking/activitymanager/ActivityManager.kt
+++ b/android/src/main/kotlin/de/buseslaar/tracking/activity_tracking/activitymanager/ActivityManager.kt
@@ -194,7 +194,10 @@ class ActivityManager {
                 locationData.put("longitude", rawLocationData.longitude);
                 locationData.put("altitude", rawLocationData.altitude);
                 locationData.put(
-                    "speed", rawLocationData.speed
+                    "speed",
+                    de.buseslaar.tracking.activity_tracking.model.Location.toKiloMetersPerHour(
+                        rawLocationData.speed
+                    )
                 );
                 val locationTime = JSONObject();
                 locationTime.put(rawLocationData.time.toString(), locationData);


### PR DESCRIPTION
The application now converts speed from meters per second (m/s) to kilometers per hour (km/h) for consistency in speed representation. This was missing in the event channel communication