### PR TITLE
Fix case-sensitive file name

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:activity_tracking/model/Location.dart';
+import 'package:activity_tracking/model/location.dart';
 import 'package:activity_tracking/model/activity.dart';
 import 'package:activity_tracking/model/activity_type.dart';
 import 'package:activity_tracking/model/message.dart';

--- a/lib/model/activity.dart
+++ b/lib/model/activity.dart
@@ -1,6 +1,6 @@
 import 'dart:ffi';
 
-import 'package:activity_tracking/model/Location.dart';
+import 'package:activity_tracking/model/location.dart';
 import 'package:activity_tracking/model/activity_type.dart';
 
 class Activity {

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -1,4 +1,4 @@
-import 'package:activity_tracking/model/Location.dart';
+import 'package:activity_tracking/model/location.dart';
 
 class Message<T> {
   String? type;


### PR DESCRIPTION
This pull request includes changes to standardize the import statements by updating the case of file names in the `activity_tracking` package. The most important changes include renaming files and updating their references accordingly.

File renaming and import statement updates:

* [`example/lib/main.dart`](diffhunk://#diff-72fd825ad17ce7800a2078e06f0dff1e12836ee59760465e78d9a5d222cebd15L3-R3): Updated import statement to use `location.dart` instead of `Location.dart`.
* [`lib/model/activity.dart`](diffhunk://#diff-d3b0b341236854b42f0cfe02e47437f636e5c6b050a5c979059a75f6cf9e8f39L3-R3): Renamed file from `Activity.dart` to `activity.dart` and updated import statement to use `location.dart` instead of `Location.dart`.
* [`lib/model/message.dart`](diffhunk://#diff-06dec1e8a5920adf1915da877b9e4948b6b1cb7648ade331e6e3c722a0ba4155L1-R1): Updated import statement to use `location.dart` instead of `Location.dart`.